### PR TITLE
Refined Landing Criteria by LMPC Planning, URDF Camera Fix & Joystick Landing Trigger

### DIFF
--- a/aerial_robot_control/include/aerial_robot_control/flight_navigation.h
+++ b/aerial_robot_control/include/aerial_robot_control/flight_navigation.h
@@ -15,6 +15,7 @@
 #include <std_msgs/Int8.h>
 #include <std_msgs/UInt8.h>
 #include <nav_msgs/Path.h>
+#include <std_msgs/Bool.h>
 #include <aerial_robot_control/trajectory/trajectory_reference/polynomial_trajectory.hpp>
 
 namespace aerial_robot_navigation
@@ -41,6 +42,7 @@ namespace aerial_robot_navigation
       ARM_ON_STATE,
       TAKEOFF_STATE,
       LAND_STATE,
+      CUSTOM_LAND_STATE,
       HOVER_STATE,
       STOP_STATE
     };
@@ -237,6 +239,7 @@ namespace aerial_robot_navigation
     ros::Publisher  power_info_pub_;
     ros::Publisher  flight_state_pub_;
     ros::Publisher  path_pub_;
+    ros::Publisher  mpc_landing_pub_;
     ros::Subscriber navi_sub_;
     ros::Subscriber pose_sub_;
     ros::Subscriber simple_move_base_goal_sub_;

--- a/aerial_robot_control/src/flight_navigation.cpp
+++ b/aerial_robot_control/src/flight_navigation.cpp
@@ -74,6 +74,8 @@ void BaseNavigator::initialize(ros::NodeHandle nh, ros::NodeHandle nhp,
   power_info_pub_ = nh_.advertise<geometry_msgs::Vector3Stamped>("uav_power", 10);
   flight_state_pub_ = nh_.advertise<std_msgs::UInt8>("flight_state", 1);
   path_pub_ = nh_.advertise<nav_msgs::Path>("trajectory", 1);
+  
+  mpc_landing_pub_ = nh_.advertise<std_msgs::Bool>("/mpc_planner/start_landing", 1);
 
   estimate_mode_ = estimator_->getEstimateMode();
   force_landing_start_time_ = ros::Time::now();
@@ -406,6 +408,40 @@ void BaseNavigator::joyStickControl(const sensor_msgs::JoyConstPtr & joy_msg)
       ROS_INFO("Joy Control: Land state");
 
       return;
+    }
+  
+  /* custom landing */
+  if(joy_cmd.buttons[JOY_BUTTON_REAR_RIGHT_1] == 1)
+    {
+      if(getNaviState() != CUSTOM_LAND_STATE && getNaviState() > START_STATE)
+        {
+          ROS_INFO("Switching to CUSTOM_LAND_STATE (MPC Landing)");
+          setNaviState(CUSTOM_LAND_STATE);
+          
+          std_msgs::Bool msg;
+          msg.data = true;
+          mpc_landing_pub_.publish(msg);
+          return;
+        }
+    }
+
+  if(joy_cmd.buttons[JOY_BUTTON_REAR_LEFT_1] == 1)
+    {
+      if(getNaviState() == CUSTOM_LAND_STATE)
+        {
+          ROS_WARN("Aborting CUSTOM_LAND_STATE -> Back to HOVER");
+          
+          // Security: Locks current position before going back to hover mode
+          setTargetXyFromCurrentState(); 
+          setTargetZFromCurrentState();
+          
+          setNaviState(HOVER_STATE);
+
+          std_msgs::Bool msg;
+          msg.data = false;
+          mpc_landing_pub_.publish(msg);
+          return;
+        }
     }
 
   teleop_reset_time_ = teleop_reset_duration_ + ros::Time::now().toSec();
@@ -831,6 +867,11 @@ void BaseNavigator::update()
             force_landing_flag_ = false;
           }
 
+        break;
+      }
+    case CUSTOM_LAND_STATE:
+      {
+        // does nothing
         break;
       }
     default:

--- a/robots/xuanwu/config/Planner.yaml
+++ b/robots/xuanwu/config/Planner.yaml
@@ -54,4 +54,4 @@ R_thrust: 0.001
 
 # --- Offsets & Compensations ---
 traj_lookahead_time: 0.5  # [s] Avanço temporal na leitura da trajetória para compensar latência
-landing_tag_offset_z: 0.12 # [m] Altura alvo acima da tag (ou ajuste do centro da tag para o chão)
+landing_tag_offset_z: 0.155 # [m] Altura alvo acima da tag (ou ajuste do centro da tag para o chão)

--- a/robots/xuanwu/src/planner_node.cpp
+++ b/robots/xuanwu/src/planner_node.cpp
@@ -355,12 +355,14 @@ private:
     x_ref(3) = 1.0; // Identity Quaternion
 
     // 4. Termination Check (Touchdown)
-    double pos_error = (x_ref.head<3>() - x_current_local.head<3>()).norm();
-    double vel_error = (x_ref.segment<3>(7) - x_current_local.segment<3>(7)).norm();
+    //double pos_error = (x_ref.head<3>() - x_current_local.head<3>()).norm();
+    double z_error = (x_ref.head<1>(2) - x_current_local.head<1>(2)).norm();
+    //double vel_error = (x_ref.segment<3>(7) - x_current_local.segment<3>(7)).norm();
+    double dz_error = (x_ref.segment<1>(9) - x_current_local.segment<1>(9)).norm();
 
     // Thresholds could also be parameters
-    if (pos_error < 0.05 && vel_error < 0.20) {
-        ROS_WARN(">> TOUCHDOWN DETECTED (Err: %.2fm). HALTING MOTORS. <<", pos_error);
+    if (z_error < 0.02 && dz_error < 0.05) {
+        ROS_WARN(">> TOUCHDOWN DETECTED (z err: %.2f m & dz_err: %.2f m/s). HALTING MOTORS. <<", z_error, dz_error);
         halt_pub_.publish(std_msgs::Empty());
         landing_active_ = false;
         return;
@@ -456,7 +458,7 @@ private:
         // Extrair dados brutos
         Eigen::Vector3d t_raw(tf_msg.transform.translation.x,
                               tf_msg.transform.translation.y,
-                              tf_msg.transform.translation.z + + landing_tag_offset_z_);
+                              tf_msg.transform.translation.z + landing_tag_offset_z_);
 
         tf2::Quaternion q_raw_tf;
         tf2::fromMsg(tf_msg.transform.rotation, q_raw_tf);

--- a/robots/xuanwu/urdf/robot.urdf.xacro
+++ b/robots/xuanwu/urdf/robot.urdf.xacro
@@ -161,7 +161,7 @@
 
   <!-- downward camera -->
   <xacro:extra_module name = "aerial_robot_camera_frame" parent = "main_body" visible = "0" >
-	  <origin xyz="-0.003 0 -0.1042" rpy="0 ${pi} ${-pi/2}"/>
+	  <origin xyz="-0.003 0 -0.159" rpy="0 ${pi} ${-pi/2}"/>
     <inertial>
       <mass value = "0.00001" />
       <origin xyz="0 0 0" rpy="0 0 0"/>


### PR DESCRIPTION
## Description
This PR iterates on the landing capabilities of the Xuanwu robot following the initial MPC integration. It refines the autonomous landing completion criteria, corrects the simulation model to match physical camera placement, and introduces a manual trigger for the MPC landing mode via the joystick.

**Note:** The landing logic and URDF changes have been validated in Gazebo. The Joystick integration is implemented but requires verification.

## Key Changes

### 1. Landing Logic Refinement
* **Halt Criteria Update:** The condition to switch from `LAND_STATE` to `STOP_STATE` (Halt) has been simplified. It now relies exclusively on **Z-axis error** and **Z-axis velocity** ($dz/dt$).
* Removed X/Y error dependencies for the halt condition to ensure the drone cuts power once it settles on the ground, regardless of small lateral drifts.

### 2. URDF/Simulation Updates
* **Camera Pose:** Updated the camera link position and orientation in the URDF to accurately reflect the real-world mounting on the physical robot.

### 3. Teleoperation (Joystick)
* **MPC Landing Trigger:** Integrated logic into `flight_navigation` to toggle the custom MPC landing state.
    * **R1 Button:** Switches to `CUSTOM_LAND_STATE` and publishes `true` to `/mpc_planner/start_landing`.
    * **L1 Button:** Aborts landing, switches back to `HOVER_STATE`, and publishes `false`.

## Testing Status

| Feature | Status | Environment |
| :--- | :--- | :--- |
| **Landing Halt Logic** | ✅ Verified | Gazebo Simulation |
| **URDF Camera Pose** | ✅ Verified | Gazebo Simulation |
| **Joystick Trigger** | ⚠️ **Untested** | Code implementation only |

## How to Run

### 1. Setup
```bash
git submodule update --init --recursive
catkin build
source devel/setup.bash

```

### 2. Validating URDF & Landing Logic (Simulation)

Launch the robot and don't forget to launch the planner manually

```bash
roslaunch xuanwu planner_manual.launch

```

### 3. Joystick Trigger behavior

* Connect the Joystick.
* Echo the trigger topic: `rostopic echo /mpc_planner/start_landing`
* **Press R1:** Verify topic receives `data: true` and state changes to `CUSTOM_LAND_STATE`.
* **Press L1:** Verify topic receives `data: false` and state reverts to `HOVER_STATE`.